### PR TITLE
fix: hide Contents sidebar in Roadmap view, fix mobile search bar & remove move-to-sidebar button

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -145,13 +145,44 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (tabMain) tabMain.classList.toggle('active', tabName === 'main');
         if (tabRoadmap) tabRoadmap.classList.toggle('active', tabName === 'roadmap');
 
+        // Update the TOC popover header title
+        const tocPopoverTitle = vectorTocPopover ? vectorTocPopover.querySelector('.popover-header h2') : null;
+        const tocPopoverTopLink = vectorTocPopover ? vectorTocPopover.querySelector('.vector-toc-top') : null;
+        const tocPopoverMoveBtn = vectorTocPopover ? vectorTocPopover.querySelector('.btn-move-sidebar') : null;
+        const infobox = document.querySelector('.mw-infobox');
+        const multiTagContainer = document.getElementById('multi-tag-container');
+
         if (tabName === 'roadmap') {
             if (firstHeading) firstHeading.textContent = 'Systems Programming Roadmap';
             if (resultsToolbar) resultsToolbar.style.display = 'none';
+            // Hide Content sidebar and show roadmap TOC in its place
+            if (sidebarContents) sidebarContents.classList.add('hidden');
+            document.body.classList.add('toc-collapsed');
+            document.body.classList.add('roadmap-active');
+            // Update popover header to "Roadmap"
+            if (tocPopoverTitle) tocPopoverTitle.textContent = 'Roadmap';
+            if (tocPopoverTopLink) tocPopoverTopLink.style.display = 'none';
+            if (tocPopoverMoveBtn) tocPopoverMoveBtn.style.display = 'none';
+            // Hide resource-specific UI elements
+            if (infobox) infobox.style.display = 'none';
+            if (multiTagContainer) multiTagContainer.style.display = 'none';
+            updateTocForRoadmap();
             renderRoadmap();
         } else {
             if (firstHeading) firstHeading.textContent = 'Learning Resources';
             if (resultsToolbar) resultsToolbar.style.display = 'flex';
+            // Restore Content sidebar and original TOC
+            document.body.classList.remove('roadmap-active');
+            if (sidebarContents) sidebarContents.classList.remove('hidden');
+            document.body.classList.remove('toc-collapsed');
+            // Restore popover header to "Contents"
+            if (tocPopoverTitle) tocPopoverTitle.textContent = 'Contents';
+            if (tocPopoverTopLink) tocPopoverTopLink.style.display = '';
+            if (tocPopoverMoveBtn) tocPopoverMoveBtn.style.display = '';
+            // Show resource-specific UI elements
+            if (infobox) infobox.style.display = '';
+            if (multiTagContainer) multiTagContainer.style.display = '';
+            initCategoryNav();
             resetAllFilters();
         }
         window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -1091,6 +1122,35 @@ document.addEventListener('DOMContentLoaded', async () => {
             case 'article':
             default:              return 'fas fa-globe';
         }
+    }
+
+    /**
+     * Update TOC popover to show roadmap steps instead of resource categories
+     */
+    function updateTocForRoadmap() {
+        const targets = [popoverTocList].filter(Boolean);
+        targets.forEach(target => {
+            target.innerHTML = '';
+            const roadmapData = API.roadmap || { intro: '', steps: [] };
+            roadmapData.steps.forEach(step => {
+                const li = document.createElement('li');
+                const a = document.createElement('a');
+                a.href = '#';
+                a.textContent = `Step ${step.number}. ${step.title}`;
+                a.title = `Jump to roadmap step: ${step.title}`;
+                a.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    closeAllPopovers();
+                    // Find the roadmap card by step number
+                    const cards = document.querySelectorAll('.mw-roadmap-card');
+                    if (cards[step.number - 1]) {
+                        cards[step.number - 1].scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    }
+                });
+                li.appendChild(a);
+                target.appendChild(li);
+            });
+        });
     }
 
     function renderRoadmap() {

--- a/www/style.css
+++ b/www/style.css
@@ -960,6 +960,7 @@ footer.vector-footer {
     /* Full-width Search Box below header top bar on mobile */
     .vector-search-box {
         order: 3;
+        flex-basis: 100%;
         width: 100%;
         margin-top: 4px;
     }
@@ -977,6 +978,7 @@ footer.vector-footer {
     .vector-search-input-wrapper input {
         width: 100%;
         flex: 1;
+        min-width: 0;
         font-size: 14px;
         padding: 8px 12px 8px 34px;
         box-sizing: border-box;
@@ -987,11 +989,17 @@ footer.vector-footer {
         padding: 8px 14px;
         font-size: 13px;
         white-space: nowrap;
+        flex-shrink: 0;
     }
 
     .vector-multi-tag-btn {
         padding: 5px 8px;
         font-size: 12px;
+    }
+
+    /* Hide "move to sidebar" buttons on mobile — sidebars aren't available */
+    .btn-move-sidebar {
+        display: none !important;
     }
 
     /* Hide Desktop Sidebars on mobile - users open them via header popover buttons */
@@ -1006,22 +1014,28 @@ footer.vector-footer {
         margin: 10px auto;
     }
 
-    /* Popover adjustments on mobile */
+    /* Popover adjustments on mobile — positioned below the taller header with search bar */
     .vector-popover {
         position: fixed;
-        top: 96px;
+        top: 108px;
         left: 10px;
         right: 10px;
         width: auto !important;
         max-width: calc(100vw - 20px);
-        max-height: 75vh;
+        max-height: calc(100vh - 120px);
         z-index: 1100;
         box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+        overflow-y: auto;
     }
 
     .vector-popover-right {
         left: 10px;
         right: 10px;
+    }
+
+    /* Hide popover arrow on mobile since positioning is different */
+    .vector-popover::before {
+        display: none;
     }
 
     .vector-article-toolbar {


### PR DESCRIPTION
## Summary

This PR improves the Roadmap tab experience and fixes mobile UI issues.

### Roadmap Tab — Context-Aware UI

When switching to the **Roadmap** tab:
- **Contents sidebar is hidden** — the resource category TOC isn't relevant to roadmap
- **TOC popover updates** to show "Roadmap" header with clickable step links that scroll to each roadmap card
- **Infobox stats** and **multi-tag filter** are hidden (resource-specific controls)
- **(Top)** link and **move to sidebar** button hidden in popover
- Everything is **fully restored** when switching back to Resources Page

### Mobile Fixes

- **Search bar full width**: Added `flex-basis: 100%` and `min-width: 0` so the search input properly spans the full width below the header controls
- **"Move to sidebar" buttons hidden**: Added `display: none !important` on mobile since sidebars aren't available on mobile viewports
- **Popover positioning fixed**: Set `top: 108px` to properly clear the taller mobile header (which includes the full-width search bar row)

### Files Changed
- `www/app.js` — `switchTab()` now manages TOC state, new `updateTocForRoadmap()` function
- `www/style.css` — Mobile responsive fixes for search bar, popover, and move-to-sidebar buttons